### PR TITLE
Schema-evolution guard: skip mixed-schema compaction rounds

### DIFF
--- a/go/FEATURES.md
+++ b/go/FEATURES.md
@@ -52,6 +52,7 @@ on the feature's main file gives the full history.
 | 17 | [Sort-on-merge from Iceberg metadata](#sort-on-merge) | Shipped | `f3918f3` | — |
 | 18 | [Dry-run mode (all 4 endpoints)](#dry-run-mode) | Shipped | `a7b6110` cut points; `a029370` wired through handlers + CompactCold + OpenAPI + tests | — |
 | 19 | [Glue registration](#glue-registration) | Shipped | `896048b` janitor-cli fast path; `ca96c63` server: metadata_location in job result + direct Glue UpdateTable | — |
+| 19a | [Schema-evolution guard (skip mixed-schema rounds)](#schema-evolution-guard) | Shipped (branch `feature/schema-evolution-guard`) | TBD on merge | PR pending |
 | 20 | [V3 deletion vectors](#refused) | Refused (safety gate) — backlog [#10](https://github.com/mystictraveler/iceberg-janitor/issues/10) | refusal in `feature/v2-deletes` (`d54e4bf`) | [#10](https://github.com/mystictraveler/iceberg-janitor/issues/10) |
 | 21 | [V3 row lineage](#refused) | Refused (safety gate) — backlog [#11](https://github.com/mystictraveler/iceberg-janitor/issues/11) | — | [#11](https://github.com/mystictraveler/iceberg-janitor/issues/11) |
 | 22 | [V3 Puffin stats](#refused) | Refused (safety gate) — backlog [#12](https://github.com/mystictraveler/iceberg-janitor/issues/12) | — | [#12](https://github.com/mystictraveler/iceberg-janitor/issues/12) |
@@ -81,6 +82,7 @@ on the feature's main file gives the full history.
 - [Sort-on-merge](#sort-on-merge)
 - [Dry-run mode](#dry-run-mode)
 - [Glue registration](#glue-registration)
+- [Schema-evolution guard](#schema-evolution-guard)
 - [Refused (safety gates)](#refused)
 - [Planned](#planned)
 
@@ -394,6 +396,104 @@ callers.
 
 - AWS bench Run 18-20: Athena queries the Glue-registered tables with no manual SQL
 - Sandbox NACL blocks Glue from Fargate; production deployments call externally — see memory note `glue_bottleneck.md`
+
+---
+
+## Schema-evolution guard
+
+**STATE: Shipped (branch `feature/schema-evolution-guard`, PR pending).**
+
+### What it does
+
+When a compaction round's source file set straddles a schema change
+(some files at schema N, others at schema N+1 after a DDL
+evolution), the janitor **skips** the round rather than producing
+silently-corrupt output. The result carries `Skipped=true`,
+`SkippedReason="mixed_schemas"`, and a `SkippedDetail` string of the
+form `"schema=1 files=45 | schema=2 files=7"` (or `fid-sig=...` when
+the schema-id metadata key is absent — see below). Before/after
+snapshot ids are equal; no transaction is staged; no rows move.
+
+### Rationale — why skip rather than rewrite
+
+**Schema evolutions are rare; compaction is continuous.** A real
+Iceberg table evolves its schema at a cadence of days to weeks —
+deliberate DDL operations like "add nullable column", "drop column",
+"widen int32 to int64". Streaming workloads, which are the janitor's
+hot path, run against a stable schema for the lifetime of the
+streamer. Compaction in contrast runs every few seconds on hot
+tables. The rate ratio is ~10⁵ or larger: compaction cycles per
+schema change.
+
+Given that asymmetry, the architecturally simple thing is for the
+compactor to respect the boundary and let time heal:
+
+- **Skip** any round whose source set spans schemas. Zero work, zero
+  risk of silent corruption, zero coupling between maintenance and DDL.
+- As the writer produces more files at the new schema, the tail at
+  schema N+1 grows. The next round's source selection window will
+  eventually contain only N+1 files and fire normally.
+- Old-schema files age out through Expire (old snapshots drop from
+  the retain set) and OrphanFiles (the recycle bin sweeps
+  unreferenced paths). Within one or two expire cycles the old
+  schema is gone from the active table entirely.
+
+**Rewriting across a schema boundary** — decoding schema-N files and
+re-encoding them at schema N+1 — is a fundamentally different
+operation than compaction. It changes data: added-column values
+become NULL in the output, dropped-column values are lost, widened
+types may overflow. That belongs in a separate `rewrite-schema` op
+if a user ever needs it, not silently bundled into compaction.
+
+### Mechanism
+
+`pkg/janitor/schema_group.go` owns the detection:
+
+- **Primary path**: parse `iceberg.schema.id` from the parquet
+  footer's key-value metadata (stamped by some Iceberg writers,
+  notably Spark).
+- **Fallback path** (used when the KV key is absent, which is the
+  case for iceberg-go-written files in v0.5.0): SHA-256 signature
+  over the sorted `(field-id, physical-type-code)` pairs for every
+  leaf column. Catches add/drop/widen evolutions without flagging
+  benign column renames (which preserve field IDs).
+- **Sign-bit collision avoidance**: signature-derived keys are
+  negated so they can never collide with a legitimate non-negative
+  schema-id from the direct-parse path.
+
+`pkg/janitor/compact_replace.go::executeStitchAndCommit` calls
+`groupPathsBySchemaID` before any write-side work. If the result has
+more than one group, `CompactResult` gets `Skipped` + reason +
+detail populated and the function returns `nil` — a no-op round, not
+an error.
+
+### Correctness evidence
+
+- `pkg/janitor/schema_evolution_test.go`:
+  - `TestCompact_SchemaEvolution_MixedSchemasSkipped` — seeds 3
+    files at the original schema, evolves with `AddColumn`, seeds 2
+    more files at the evolved schema, runs `Compact`, verifies
+    `Skipped=true` + `SkippedReason="mixed_schemas"` + snapshot id
+    unchanged + file/row counts unchanged.
+  - `TestCompact_SchemaEvolution_SingleSchemaRunsNormally` — evolves
+    FIRST, then seeds 5 files all at the evolved schema, confirms
+    `Skipped=false` and normal file reduction.
+- Full `go test ./...` green on `feature/schema-evolution-guard`
+  (all 29 packages).
+
+### Known gaps
+
+- `SkippedDetail` currently shows `fid-sig=<hex>` because iceberg-go
+  doesn't stamp `iceberg.schema.id` in parquet KV metadata today.
+  Functionally correct — grouping still fires — but less friendly
+  than `schema=1 files=45 | schema=2 files=7`. If iceberg-go adds
+  the stamp (or Spark is the writer), the detail string uses the
+  friendlier form automatically.
+- The guard refuses mixed rounds but does not OFFER the per-group
+  compaction alternative (produce N output files, one per schema
+  version, in one transaction). Per the rationale above, that's a
+  deliberate non-feature — if a user needs it, the right shape is a
+  dedicated `rewrite-schema` op.
 
 ---
 

--- a/go/pkg/janitor/compact.go
+++ b/go/pkg/janitor/compact.go
@@ -244,6 +244,19 @@ type CompactResult struct {
 	ContentionDetected bool `json:"contention_detected,omitempty"`
 	PlannedOldFiles    int  `json:"planned_old_files,omitempty"`
 	PlannedNewFiles    int  `json:"planned_new_files,omitempty"`
+
+	// Skipped is set when compaction deliberately did NOT run — the
+	// source set was either empty (already compacted / nothing to do)
+	// or crossed a schema-evolution boundary (SkippedReason =
+	// "mixed_schemas"). Skipped runs are NOT failures: BeforeSnapshotID
+	// == AfterSnapshotID, zero rows moved. See SkippedReason for the
+	// discriminator.
+	Skipped       bool   `json:"skipped,omitempty"`
+	SkippedReason string `json:"skipped_reason,omitempty"`
+	// SkippedDetail is a short human-readable description useful in
+	// logs and dashboards, e.g.
+	//   "schema=1 files=45 | schema=2 files=7"
+	SkippedDetail string `json:"skipped_detail,omitempty"`
 }
 
 // Compact rewrites the table's data files via the parquet-go-direct

--- a/go/pkg/janitor/compact_replace.go
+++ b/go/pkg/janitor/compact_replace.go
@@ -419,6 +419,34 @@ func executeStitchAndCommit(
 	result *CompactResult,
 	cat *catalog.DirectoryCatalog,
 ) error {
+	// Schema-evolution guard. Before any write, group the source
+	// paths by parquet schema-id (peeked from the footer's iceberg.
+	// schema.id metadata, or a field-id signature fallback). A mixed
+	// result means the source set straddles a schema change: refuse
+	// loudly-but-softly by recording Skipped and returning nil. The
+	// caller's BeforeSnapshotID == AfterSnapshotID is preserved and
+	// the round completes as a no-op. See pkg/janitor/schema_group.go
+	// for the full rationale (TL;DR: schema evolutions are rare
+	// relative to compaction cadence; let the old-schema tail age out
+	// rather than rewrite across the boundary).
+	if len(oldPaths) > 1 {
+		ctx2, schemaSpan := tr.Start(ctx, "schema_group_check")
+		groups, gerr := groupPathsBySchemaID(ctx2, fs, oldPaths)
+		schemaSpan.End()
+		if gerr != nil {
+			return fmt.Errorf("grouping source files by schema: %w", gerr)
+		}
+		if len(groups) > 1 {
+			result.Skipped = true
+			result.SkippedReason = "mixed_schemas"
+			result.SkippedDetail = describeSchemaGroups(groups)
+			result.AfterSnapshotID = result.BeforeSnapshotID
+			result.AfterFiles = result.BeforeFiles
+			result.AfterRows = result.BeforeRows
+			return nil
+		}
+	}
+
 	// V2 delete handling: load every delete-file payload that the
 	// manifest walk collected. If any eq delete references a column
 	// type we can't safely compare, BuildDeleteBundle returns an

--- a/go/pkg/janitor/schema_evolution_test.go
+++ b/go/pkg/janitor/schema_evolution_test.go
@@ -1,0 +1,180 @@
+package janitor_test
+
+import (
+	"context"
+	"testing"
+
+	icebergpkg "github.com/apache/iceberg-go"
+	icebergtable "github.com/apache/iceberg-go/table"
+
+	"github.com/mystictraveler/iceberg-janitor/go/pkg/janitor"
+	"github.com/mystictraveler/iceberg-janitor/go/pkg/testutil"
+)
+
+// TestCompact_SchemaEvolution_MixedSchemasSkipped is the correctness
+// proof for the schema-evolution guard. It confirms that when a
+// table's file set spans two schema versions, Compact refuses to
+// cross the boundary: no write, no snapshot advance, no row loss. The
+// round is marked Skipped with SkippedReason="mixed_schemas" so an
+// operator can see the deferral in metrics or job logs.
+//
+// Rationale: schema evolutions on real tables happen at a cadence of
+// days to weeks; compaction runs every few seconds on hot tables.
+// Rather than rewriting data across a schema boundary (which would
+// silently change column cardinality, lose dropped-column values,
+// etc.), the janitor skips mixed rounds and lets the old-schema tail
+// age out through Expire + OrphanFiles. See pkg/janitor/schema_group.go
+// for the full rationale.
+func TestCompact_SchemaEvolution_MixedSchemasSkipped(t *testing.T) {
+	w := testutil.NewWarehouse(t)
+	schema := testutil.SimpleFactSchema()
+	tbl := w.CreateTable(t, "se", "events", schema)
+
+	// Seed 3 batches at the ORIGINAL schema — schema id 0 on a fresh
+	// table. Each Append is one commit → one data file.
+	for i := 0; i < 3; i++ {
+		rows := make([]testutil.SimpleFactRow, 4)
+		for j := 0; j < 4; j++ {
+			rows[j] = testutil.SimpleFactRow{
+				ID:     int64(i*4 + j),
+				Value:  int64(j),
+				Region: "us",
+			}
+		}
+		tbl = testutil.AppendSimpleFactRows(t, tbl, rows)
+	}
+
+	// Evolve the schema: add a nullable "extra" column. iceberg-go's
+	// UpdateSchema API stamps the new schema at schema_id+1; a
+	// subsequent Append writes parquet with the evolved schema and
+	// the new iceberg.schema.id key in the footer.
+	tx := tbl.NewTransaction()
+	if err := tx.UpdateSchema(true, false).
+		AddColumn([]string{"extra"}, icebergpkg.PrimitiveTypes.String, "evolved column", false, nil).
+		Commit(); err != nil {
+		t.Fatalf("UpdateSchema.Commit: %v", err)
+	}
+	var err error
+	tbl, err = tx.Commit(context.Background())
+	if err != nil {
+		t.Fatalf("evolve commit: %v", err)
+	}
+
+	// Seed 2 more batches at the evolved schema. The testutil helper
+	// writes Arrow records using the table's CURRENT schema, so the
+	// parquet files stamp the NEW schema_id.
+	for i := 0; i < 2; i++ {
+		rows := make([]testutil.SimpleFactRow, 4)
+		for j := 0; j < 4; j++ {
+			rows[j] = testutil.SimpleFactRow{
+				ID:     int64(100 + i*4 + j),
+				Value:  int64(j + 100),
+				Region: "eu",
+			}
+		}
+		tbl = testutil.AppendSimpleFactRows(t, tbl, rows)
+	}
+
+	// Pre-compact: 5 data files, 3 at schema-v0 and 2 at schema-v1.
+	beforeFiles, beforeRows := janitor.SnapshotFileStatsFast(context.Background(), tbl)
+	if beforeFiles != 5 {
+		t.Fatalf("before files = %d, want 5", beforeFiles)
+	}
+	if beforeRows != 20 {
+		t.Fatalf("before rows = %d, want 20", beforeRows)
+	}
+	beforeSnap := tbl.CurrentSnapshot().SnapshotID
+
+	// Act: Compact. Expected: mixed-schemas skip.
+	res, cerr := janitor.Compact(context.Background(), w.Cat,
+		icebergtable.Identifier{"se", "events"}, janitor.CompactOptions{
+			TargetFileSizeBytes: 128 * 1024 * 1024,
+		})
+	if cerr != nil {
+		t.Fatalf("Compact returned error (should have returned nil-with-skip): %v", cerr)
+	}
+
+	// Verify the skip was recorded correctly.
+	if !res.Skipped {
+		t.Errorf("expected Skipped=true, got false")
+	}
+	if res.SkippedReason != "mixed_schemas" {
+		t.Errorf("SkippedReason = %q, want %q", res.SkippedReason, "mixed_schemas")
+	}
+	if res.SkippedDetail == "" {
+		t.Errorf("SkippedDetail should be populated with per-group breakdown, got empty string")
+	}
+	t.Logf("skipped_detail: %s", res.SkippedDetail)
+
+	// Verify the snapshot did NOT advance — the table is untouched.
+	reloaded := w.LoadTable(t, "se", "events")
+	afterSnap := reloaded.CurrentSnapshot().SnapshotID
+	if afterSnap != beforeSnap {
+		t.Errorf("snapshot advanced: %d → %d, want no change (mixed-schema skip must not write)",
+			beforeSnap, afterSnap)
+	}
+
+	// Verify file + row counts unchanged.
+	afterFiles, afterRows := janitor.SnapshotFileStatsFast(context.Background(), reloaded)
+	if afterFiles != beforeFiles {
+		t.Errorf("after files = %d, want %d (unchanged)", afterFiles, beforeFiles)
+	}
+	if afterRows != beforeRows {
+		t.Errorf("after rows = %d, want %d (no row loss)", afterRows, beforeRows)
+	}
+}
+
+// TestCompact_SchemaEvolution_SingleSchemaRunsNormally is the
+// happy-path check that proves the guard only skips when schemas
+// actually differ. With all source files at the same (post-
+// evolution) schema, Compact succeeds and reduces the file count.
+func TestCompact_SchemaEvolution_SingleSchemaRunsNormally(t *testing.T) {
+	w := testutil.NewWarehouse(t)
+	schema := testutil.SimpleFactSchema()
+	tbl := w.CreateTable(t, "se", "events", schema)
+
+	// Evolve the schema BEFORE seeding any data. All subsequent files
+	// will be written at the evolved schema.
+	tx := tbl.NewTransaction()
+	if err := tx.UpdateSchema(true, false).
+		AddColumn([]string{"extra"}, icebergpkg.PrimitiveTypes.String, "evolved column", false, nil).
+		Commit(); err != nil {
+		t.Fatalf("UpdateSchema.Commit: %v", err)
+	}
+	var err error
+	tbl, err = tx.Commit(context.Background())
+	if err != nil {
+		t.Fatalf("evolve commit: %v", err)
+	}
+
+	// Seed 5 batches all at the evolved schema.
+	for i := 0; i < 5; i++ {
+		rows := make([]testutil.SimpleFactRow, 4)
+		for j := 0; j < 4; j++ {
+			rows[j] = testutil.SimpleFactRow{
+				ID:     int64(i*4 + j),
+				Value:  int64(j),
+				Region: "us",
+			}
+		}
+		tbl = testutil.AppendSimpleFactRows(t, tbl, rows)
+	}
+
+	res, cerr := janitor.Compact(context.Background(), w.Cat,
+		icebergtable.Identifier{"se", "events"}, janitor.CompactOptions{
+			TargetFileSizeBytes: 128 * 1024 * 1024,
+		})
+	if cerr != nil {
+		t.Fatalf("Compact: %v", cerr)
+	}
+	if res.Skipped {
+		t.Errorf("single-schema round should NOT be skipped (got SkippedReason=%q, Detail=%q)",
+			res.SkippedReason, res.SkippedDetail)
+	}
+	if res.AfterFiles >= res.BeforeFiles {
+		t.Errorf("expected file reduction, got before=%d after=%d", res.BeforeFiles, res.AfterFiles)
+	}
+	if res.AfterRows != res.BeforeRows {
+		t.Errorf("row count changed: before=%d after=%d", res.BeforeRows, res.AfterRows)
+	}
+}

--- a/go/pkg/janitor/schema_group.go
+++ b/go/pkg/janitor/schema_group.go
@@ -1,0 +1,261 @@
+package janitor
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"sort"
+	"strconv"
+	"sync"
+
+	icebergio "github.com/apache/iceberg-go/io"
+	pqgo "github.com/parquet-go/parquet-go"
+	"golang.org/x/sync/errgroup"
+)
+
+// Schema-evolution guard.
+//
+// The byte-copy stitch assumes every source file in a compaction round
+// has the same parquet schema (same column set, same field IDs). When
+// a user evolves the Iceberg schema (adds a nullable column, drops an
+// old one), new files are written at schema_id = N+1 and old files
+// stay at schema_id = N. Mixing the two in one byte-copy stitch would
+// silently corrupt the output (wrong column cardinality, missing or
+// extra chunks).
+//
+// # Why "skip" is the right policy, not "rewrite across the boundary"
+//
+// Schema evolutions on a real Iceberg table are RARE events — days or
+// weeks apart, not minutes. Streaming workloads (the janitor's hot
+// path) typically run against a stable schema for the lifetime of the
+// streamer; evolutions happen out-of-band via a deliberate DDL
+// change. Compaction, in contrast, runs continuously — every few
+// seconds on a hot table. The rate ratio is roughly 10^5 or larger:
+// compaction cycles per schema change.
+//
+// Given that asymmetry, the architecturally simple thing is to make
+// the compactor respect the boundary and let time heal:
+//
+//   - Skip any compaction round whose source set spans schemas. No
+//     work, no risk of silent corruption, no coupling between
+//     maintenance and DDL.
+//   - As the writer produces more files at the new schema, the
+//     schema-N+1 tail naturally grows. The next compaction round's
+//     source selection window will eventually contain only N+1 files,
+//     at which point it fires normally.
+//   - Schema-N files left over age out through Expire (old snapshots
+//     fall off the retain set, their unique data-file references
+//     drop) and OrphanFiles (the recycle bin sweeps unreferenced
+//     paths). Within one or two expire cycles the old schema is gone
+//     from the active table entirely.
+//
+// The alternative — "rewrite across the boundary" — means decoding
+// schema-N files and re-encoding them at schema N+1. That's not
+// compaction anymore; it's a schema rewrite, a fundamentally
+// different operation with different correctness risks (added column
+// values become NULL in the output, dropped column values are lost
+// irretrievably, type-widened values may overflow). It belongs in a
+// separate `rewrite-schema` op if a user ever needs it, NOT silently
+// bundled into the compactor.
+//
+// We handle this by refusing to cross schema-change boundaries: when
+// a compaction round's source set contains files at more than one
+// schema_id, the round is SKIPPED (not errored). The caller records
+// SkippedReason="mixed_schemas" in the CompactResult and moves on.
+//
+// # How we detect the boundary
+//
+// iceberg-go v0.5.0 does not expose per-entry schema_id on the public
+// DataFile interface (the spec records it in the manifest entry but
+// iceberg-go's Go struct doesn't surface the field), and the
+// iceberg-go writer does not stamp "iceberg.schema.id" in parquet
+// key-value metadata either. So we derive a per-file "schema group"
+// from the parquet footer:
+//
+//   - If the "iceberg.schema.id" KV key IS present (Spark, some
+//     catalogs stamp it), we parse it and use the int directly.
+//   - Otherwise we compute a field-ID + physical-type signature from
+//     the parquet schema: SHA-256 over the sorted (field-id, type-
+//     code) pairs for every leaf column. Two files with the same
+//     signature have the same parquet chunk layout, which is the
+//     property that matters for byte-copy stitch.
+//
+// The signature catches the four schema changes that matter for
+// compaction:
+//
+//   - Add column     → new field-id appears      → signature differs
+//   - Drop column    → field-id disappears       → signature differs
+//   - Widen type     → same field-id, new code   → signature differs
+//   - Rename column  → field-id unchanged        → signature matches
+//     (benign — byte-copy is name-agnostic once field-IDs line up)
+//
+// Sign bit on the signature path: the returned schemaGroupKey is
+// negated so it cannot collide with a legitimate non-negative
+// schema-id from the direct-parse path, preventing cross-mechanism
+// collisions.
+
+// icebergSchemaIDKey is the parquet key-value metadata key iceberg-go
+// stamps on every file it writes for an Iceberg table. Value is the
+// decimal string of the schema-id at write time.
+const icebergSchemaIDKey = "iceberg.schema.id"
+
+// schemaGroupKey is the per-file grouping identifier used by
+// groupPathsBySchemaID. When the iceberg.schema.id metadata key is
+// present, this is the parsed int. When absent, it's a 64-bit FNV-
+// style hash of the sorted top-level field-ID list, negated so it
+// can't collide with a real non-negative schema-id.
+type schemaGroupKey int64
+
+// readSchemaGroup returns the schema group for one parquet file.
+// Cost: one parquet footer read (cheap — bounded range GET at end of
+// file). Callers should batch via groupPathsBySchemaID to parallelize.
+func readSchemaGroup(ctx context.Context, fs icebergio.IO, path string) (schemaGroupKey, error) {
+	f, err := fs.Open(path)
+	if err != nil {
+		return 0, fmt.Errorf("opening %s: %w", path, err)
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return 0, fmt.Errorf("stat %s: %w", path, err)
+	}
+	pf, err := pqgo.OpenFile(f, info.Size())
+	if err != nil {
+		return 0, fmt.Errorf("parse parquet %s: %w", path, err)
+	}
+	// Preferred signal: iceberg.schema.id in key-value metadata.
+	for _, kv := range pf.Metadata().KeyValueMetadata {
+		if kv.Key == icebergSchemaIDKey && kv.Value != "" {
+			id, perr := strconv.Atoi(kv.Value)
+			if perr == nil {
+				return schemaGroupKey(id), nil
+			}
+			// If the key is present but garbage, fall through to
+			// the signature path rather than error — the signature
+			// is still correct for grouping.
+		}
+	}
+	return fieldIDSignature(pf), nil
+}
+
+// fieldIDSignature produces a stable negative int64 hash of the sorted
+// top-level field-ID list of a parquet file. Used when the iceberg
+// schema-id metadata key is absent so we can still group files by
+// their column content. The sign bit guarantees it can't collide with
+// a legitimate schema-id (which is always non-negative).
+func fieldIDSignature(pf *pqgo.File) schemaGroupKey {
+	schema := pf.Schema()
+	// parquet-go's Schema.Columns() returns column PATHS as [][]string.
+	// For iceberg-written parquet, top-level field IDs are stored on
+	// each SchemaElement's FieldID. We read them straight from the
+	// FileMetaData.Schema flat list.
+	// Collect (field-id, physical-type) pairs for every leaf column.
+	// Including the type catches widening evolutions (int32 → int64,
+	// float32 → float64, decimal precision/scale changes) which keep
+	// the same field-id set but change the on-disk chunk width —
+	// byte-copy would produce wrong-width chunks in the output.
+	type fieldEntry struct {
+		id       int32
+		typeCode int32
+	}
+	var entries []fieldEntry
+	for _, se := range pf.Metadata().Schema {
+		// FieldID is optional in the Thrift definition; 0 is the
+		// zero-value and iceberg-go populates a real positive ID on
+		// every leaf column. Skipping 0 keeps the signature stable
+		// across parquet-go versions that differ on how the root
+		// element's FieldID is marshalled.
+		if se.FieldID != 0 {
+			var tc int32 = -1 // "no type" distinct from any parquet-go Type value
+			if se.Type.Valid {
+				tc = int32(se.Type.V)
+			}
+			entries = append(entries, fieldEntry{
+				id:       se.FieldID,
+				typeCode: tc,
+			})
+		}
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].id < entries[j].id })
+	h := sha256.New()
+	buf := make([]byte, 8)
+	for _, e := range entries {
+		binary.LittleEndian.PutUint32(buf[:4], uint32(e.id))
+		binary.LittleEndian.PutUint32(buf[4:], uint32(e.typeCode))
+		h.Write(buf)
+	}
+	_ = schema // silence unused — kept in the signature for documentation clarity
+	sum := h.Sum(nil)
+	// Take the low 63 bits and negate so it can't collide with a real
+	// schema-id (which is always non-negative).
+	n := int64(binary.LittleEndian.Uint64(sum[:8])) & 0x7FFFFFFFFFFFFFFF
+	return schemaGroupKey(-1 - n)
+}
+
+// groupPathsBySchemaID reads each path's parquet footer in parallel
+// and returns a map keyed by schema group. A compaction round is safe
+// to run only when the returned map has exactly one entry.
+//
+// The bounded concurrency matches the stitch file-open loop —
+// footer reads dominate on high-latency S3; 32 workers amortize.
+func groupPathsBySchemaID(ctx context.Context, fs icebergio.IO, paths []string) (map[schemaGroupKey][]string, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	keys := make([]schemaGroupKey, len(paths))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(parquetReadConcurrency)
+	for i, p := range paths {
+		i, p := i, p
+		g.Go(func() error {
+			if gctx.Err() != nil {
+				return gctx.Err()
+			}
+			k, err := readSchemaGroup(gctx, fs, p)
+			if err != nil {
+				return err
+			}
+			keys[i] = k
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	groups := make(map[schemaGroupKey][]string, 2)
+	for i, p := range paths {
+		groups[keys[i]] = append(groups[keys[i]], p)
+	}
+	return groups, nil
+}
+
+// describeSchemaGroups formats a stable, short description of the
+// groups for logging/metrics. "schema=1 files=45 | schema=2 files=7".
+// Called only on the mixed-schemas skip path, so cost is irrelevant.
+func describeSchemaGroups(groups map[schemaGroupKey][]string) string {
+	type kv struct {
+		k schemaGroupKey
+		n int
+	}
+	var rows []kv
+	for k, v := range groups {
+		rows = append(rows, kv{k, len(v)})
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].k < rows[j].k })
+	var b []byte
+	for i, r := range rows {
+		if i > 0 {
+			b = append(b, " | "...)
+		}
+		if r.k < 0 {
+			// signature fallback
+			b = append(b, []byte(fmt.Sprintf("fid-sig=%x files=%d", uint64(-r.k-1), r.n))...)
+		} else {
+			b = append(b, []byte(fmt.Sprintf("schema=%d files=%d", int64(r.k), r.n))...)
+		}
+	}
+	return string(b)
+}
+
+var _ = sync.Once{} // reserved for future memoization


### PR DESCRIPTION
## Summary

Compaction's byte-copy stitch assumes uniform schema across source files. When a table evolves its schema (add column, drop column, widen int32→int64), files written at schema N and schema N+1 cannot be byte-copy-stitched together without silently corrupting the output. This PR adds a guard that **skips** any compaction round whose source set spans schemas, recording `Skipped=true` + `SkippedReason="mixed_schemas"` on the `CompactResult`. No write, no snapshot advance, no row movement.

## Rationale — why skip, not rewrite

Schema evolutions on real Iceberg tables happen at a cadence of days to weeks. Compaction runs every few seconds on hot tables. The rate ratio is ~10⁵ or larger (compaction cycles per schema change). Given that asymmetry, the architecturally simple thing is to let time heal: as the writer produces more files at the new schema, the N+1 tail grows, and the next compaction round's source selection will eventually contain only N+1 files. Old-schema files age out through Expire + OrphanFiles naturally.

Rewriting across a schema boundary is a fundamentally different operation than compaction — added-column values become NULL, dropped-column values are lost, widened types may overflow. That belongs in a separate `rewrite-schema` op if ever needed, not silently bundled into the compactor.

## Mechanism

- `pkg/janitor/schema_group.go` — per-file schema grouping. Reads `iceberg.schema.id` from parquet footer KV metadata when present (Spark, some other writers stamp it); falls back to a SHA-256 signature over sorted `(field-id, physical-type-code)` pairs from the parquet schema. Catches the four schema changes that matter for byte-copy: add-column, drop-column, widen-type, and leaves rename (same field IDs) untouched.
- `pkg/janitor/compact_replace.go` — `executeStitchAndCommit` calls `groupPathsBySchemaID` before any write. Mixed result → skip.
- `pkg/janitor/compact.go` — `CompactResult` gains `Skipped` + `SkippedReason` + `SkippedDetail` (omitempty JSON).

## Ship checklist

- [x] Unit + integration suite: `cd go && go test ./...` — 29 packages ok
- [x] Vet clean: `cd go && go vet ./...`
- [x] New correctness tests pass:
  - [x] `TestCompact_SchemaEvolution_MixedSchemasSkipped` — seed at schema-v0, evolve, seed at schema-v1, run Compact → skip with correct reason + details, snapshot unchanged
  - [x] `TestCompact_SchemaEvolution_SingleSchemaRunsNormally` — evolve first, seed all at the evolved schema, run Compact → normal file reduction
- [x] **MinIO bench regression check** — `WORKLOAD=deletes bash go/test/bench/bench.sh minio`, 10K rows / 50 deletes, before vs after:

  | Branch | Run 1 | Run 2 | Mean | File reduction | Row count | Master |
  |---|---|---|---|---|---|---|
  | `main` (no guard) | 822 ms | 828 ms | **825 ms** | 200 → 1 (200×) | 10000 → 9950 | PASS |
  | `feature/schema-evolution-guard` | 920 ms | 861 ms | **891 ms** | 200 → 1 (200×) | 10000 → 9950 | PASS |

  **Δ = +66 ms (+8 %)** — within MinIO-on-Docker run-to-run noise (~60-100 ms) and consistent with expected overhead: one parquet footer read per source file before the stitch, 32-way parallel. Theoretical bound ~125 ms; observed 66 ms because footer reads are small range GETs. No correctness regression: identical file reduction, identical row counts, master check PASS on every run.

## Known gaps

- `SkippedDetail` shows `fid-sig=<hex>` today because iceberg-go v0.5.0 doesn't stamp `iceberg.schema.id` in parquet KV metadata. Functionally correct; less friendly than `schema=1 files=45 | schema=2 files=7`. If iceberg-go adds the stamp (or Spark is the writer), the detail string uses the friendlier form automatically.
- The guard refuses mixed rounds but does not offer a per-group compaction alternative (producing N output files, one per schema version, in one transaction). Per the rationale above, that's a deliberate non-feature.

## Commits

```
280b98d Schema-evolution guard: skip mixed-schema compaction rounds
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
